### PR TITLE
변경된 하나의 Card만 카드리스트에 반영

### DIFF
--- a/client-mobile/ToDoListApp/ToDoListApp.xcodeproj/project.pbxproj
+++ b/client-mobile/ToDoListApp/ToDoListApp.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		380A5AE1243C5A360063A9F6 /* BedgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A5AE0243C5A360063A9F6 /* BedgeView.swift */; };
+		380A5AE1243C5A360063A9F6 /* BadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A5AE0243C5A360063A9F6 /* BadgeView.swift */; };
 		381C3A52243B505F00F83D4B /* CardListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 381C3A51243B505F00F83D4B /* CardListDataSource.swift */; };
 		3830F72B243D9F2400C03FEB /* CardTitleTextFieldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3830F72A243D9F2400C03FEB /* CardTitleTextFieldDelegate.swift */; };
 		3831B96B243B51D600550FA1 /* CardListDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3831B96A243B51D600550FA1 /* CardListDelegate.swift */; };
@@ -33,7 +33,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		380A5AE0243C5A360063A9F6 /* BedgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BedgeView.swift; sourceTree = "<group>"; };
+		380A5AE0243C5A360063A9F6 /* BadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeView.swift; sourceTree = "<group>"; };
 		381C3A51243B505F00F83D4B /* CardListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListDataSource.swift; sourceTree = "<group>"; };
 		3830F72A243D9F2400C03FEB /* CardTitleTextFieldDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardTitleTextFieldDelegate.swift; sourceTree = "<group>"; };
 		3831B96A243B51D600550FA1 /* CardListDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListDelegate.swift; sourceTree = "<group>"; };
@@ -77,7 +77,7 @@
 				381C3A51243B505F00F83D4B /* CardListDataSource.swift */,
 				3831B96A243B51D600550FA1 /* CardListDelegate.swift */,
 				3831B970243B58DF00550FA1 /* CardCell.swift */,
-				380A5AE0243C5A360063A9F6 /* BedgeView.swift */,
+				380A5AE0243C5A360063A9F6 /* BadgeView.swift */,
 				387B8B3A243CBFEE00805A34 /* ColumnView.swift */,
 			);
 			path = CardList;
@@ -272,7 +272,7 @@
 				388CA27C243AEE0900E99CED /* AppDelegate.swift in Sources */,
 				388CA27E243AEE0900E99CED /* SceneDelegate.swift in Sources */,
 				3831B971243B58DF00550FA1 /* CardCell.swift in Sources */,
-				380A5AE1243C5A360063A9F6 /* BedgeView.swift in Sources */,
+				380A5AE1243C5A360063A9F6 /* BadgeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/client-mobile/ToDoListApp/ToDoListApp.xcodeproj/project.pbxproj
+++ b/client-mobile/ToDoListApp/ToDoListApp.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		38B43793243D85B3000C2A8D /* NewCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B43792243D85B3000C2A8D /* NewCardViewController.swift */; };
 		38B43795243D9241000C2A8D /* CardContentsTextViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38B43794243D9241000C2A8D /* CardContentsTextViewDelegate.swift */; };
 		38E05A49243F7436005679EC /* TItleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E05A48243F7436005679EC /* TItleViewModel.swift */; };
+		38F0A3E8244406AB00A20EF5 /* CardListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F0A3E7244406AB00A20EF5 /* CardListViewModel.swift */; };
 		38F437E324401EFC009BE1FF /* ContentsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F437E224401EFC009BE1FF /* ContentsViewModel.swift */; };
 		38F437E524403AE7009BE1FF /* UserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F437E424403AE7009BE1FF /* UserData.swift */; };
 /* End PBXBuildFile section */
@@ -54,6 +55,7 @@
 		38B43792243D85B3000C2A8D /* NewCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewCardViewController.swift; sourceTree = "<group>"; };
 		38B43794243D9241000C2A8D /* CardContentsTextViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardContentsTextViewDelegate.swift; sourceTree = "<group>"; };
 		38E05A48243F7436005679EC /* TItleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TItleViewModel.swift; sourceTree = "<group>"; };
+		38F0A3E7244406AB00A20EF5 /* CardListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListViewModel.swift; sourceTree = "<group>"; };
 		38F437E224401EFC009BE1FF /* ContentsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentsViewModel.swift; sourceTree = "<group>"; };
 		38F437E424403AE7009BE1FF /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -165,6 +167,7 @@
 			isa = PBXGroup;
 			children = (
 				38AB7CBF243F0D3D00ADD8F8 /* ColumnViewModel.swift */,
+				38F0A3E7244406AB00A20EF5 /* CardListViewModel.swift */,
 				38F437E124401EEA009BE1FF /* NewCard */,
 			);
 			path = ViewModels;
@@ -250,6 +253,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				38F0A3E8244406AB00A20EF5 /* CardListViewModel.swift in Sources */,
 				3831B96B243B51D600550FA1 /* CardListDelegate.swift in Sources */,
 				387B8B35243C977D00805A34 /* ColumnViewController.swift in Sources */,
 				388CA280243AEE0900E99CED /* ToDoListViewController.swift in Sources */,

--- a/client-mobile/ToDoListApp/ToDoListApp/Base.lproj/Main.storyboard
+++ b/client-mobile/ToDoListApp/ToDoListApp/Base.lproj/Main.storyboard
@@ -113,7 +113,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zxy-Eb-ORH" customClass="BedgeView" customModule="ToDoListApp" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zxy-Eb-ORH" customClass="BadgeView" customModule="ToDoListApp" customModuleProvider="target">
                                                 <rect key="frame" x="16" y="15" width="26" height="26"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RVR-Z0-nPN">
@@ -238,8 +238,8 @@ sdasdsad</string>
                     </view>
                     <connections>
                         <outlet property="addCardButton" destination="dh1-4d-aLD" id="7pB-XK-4Hw"/>
-                        <outlet property="bedgeLabel" destination="RVR-Z0-nPN" id="ubP-pz-OIX"/>
-                        <outlet property="bedgeView" destination="Zxy-Eb-ORH" id="D2S-IB-6St"/>
+                        <outlet property="badgeLabel" destination="RVR-Z0-nPN" id="32Z-xi-OjJ"/>
+                        <outlet property="badgeView" destination="Zxy-Eb-ORH" id="X55-kq-Y3s"/>
                         <outlet property="columnNameLabel" destination="nQM-V2-vXo" id="gKo-uF-OAb"/>
                         <outlet property="columnView" destination="nC1-T4-bH7" id="OIY-A8-ZcE"/>
                         <outlet property="tableView" destination="MK3-04-ZMa" id="JH8-Lb-5xz"/>

--- a/client-mobile/ToDoListApp/ToDoListApp/Base.lproj/Main.storyboard
+++ b/client-mobile/ToDoListApp/ToDoListApp/Base.lproj/Main.storyboard
@@ -142,7 +142,7 @@
                                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <state key="normal" image="plus" catalog="system"/>
                                                 <connections>
-                                                    <action selector="addNewCardButtonTapped:" destination="tTc-I3-ac2" eventType="touchUpInside" id="oDH-c6-HhT"/>
+                                                    <action selector="toAddNewCardButtonTapped:" destination="tTc-I3-ac2" eventType="touchUpInside" id="oDH-c6-HhT"/>
                                                 </connections>
                                             </button>
                                         </subviews>

--- a/client-mobile/ToDoListApp/ToDoListApp/Models/CardList/Column.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/Models/CardList/Column.swift
@@ -19,8 +19,4 @@ struct Column: Codable {
         case name = "columnName"
         case cards
     }
-    
-    mutating func insertCard(_ card: Card, at index: Int) {
-        cards.insert(card, at: index)
-    }
 }

--- a/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
@@ -13,8 +13,8 @@ class ColumnViewController: UIViewController, NewCardDelegation {
     static let identifier = "Column"
     
     @IBOutlet weak var columnView: ColumnView!
-    @IBOutlet weak var bedgeView: BedgeView!
-    @IBOutlet weak var bedgeLabel: UILabel!
+    @IBOutlet weak var badgeView: BadgeView!
+    @IBOutlet weak var badgeLabel: UILabel!
     @IBOutlet weak var columnNameLabel: UILabel!
     @IBOutlet weak var addCardButton: UIButton!
     
@@ -47,8 +47,8 @@ class ColumnViewController: UIViewController, NewCardDelegation {
     }
     
     private func configureColumnView() {
-        columnView.bedgeView = bedgeView
-        columnView.bedgeLabel = bedgeLabel
+        columnView.badgeView = badgeView
+        columnView.badgeLabel = badgeLabel
         columnView.nameLabel = columnNameLabel
         columnView.addCardButton = addCardButton
     }
@@ -56,7 +56,7 @@ class ColumnViewController: UIViewController, NewCardDelegation {
     private func updateColumn(_ column: Column?) {
         guard let column = column else { return }
         columnView.updateName(column.name)
-        columnView.updateBedge(column.cards)
+        columnView.updateBadge(column.cards)
         dataSource.cards = column.cards
         tableView.reloadData()
     }

--- a/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
@@ -35,28 +35,6 @@ class ColumnViewController: UIViewController, NewCardDelegation {
         columnViewModel?.updateColumn(column)
     }
     
-    private func configureViewModelHandler() {
-        columnViewModel?.updateNotify(changed: { (column) in
-            self.updateColumn(column)
-            self.cardListViewModel.updateCardList(column?.cards)
-        })
-        cardListViewModel.updateNotify { (cardList) in
-            self.cardListDataSource.updateCardList(cardList)
-        }
-    }
-    
-    private func configureTableView() {
-        tableView.dataSource = cardListDataSource
-        tableView.delegate = cardListDelegate
-    }
-    
-    private func configureColumnView() {
-        columnView.badgeView = badgeView
-        columnView.badgeLabel = badgeLabel
-        columnView.nameLabel = columnNameLabel
-        columnView.addCardButton = addCardButton
-    }
-    
     private func updateColumn(_ column: Column?) {
         guard let column = column else { return }
         columnView.updateName(column.name)
@@ -77,5 +55,31 @@ class ColumnViewController: UIViewController, NewCardDelegation {
         cardListViewModel.insertCard(card, at: 0)
         tableView.insertRows(at: [IndexPath(row: 0, section: 0)], with: .top)
         tableView.endUpdates()
+    }
+}
+
+extension ColumnViewController {
+    
+    // MARK:- Configuration
+    private func configureViewModelHandler() {
+        columnViewModel?.updateNotify(changed: { (column) in
+            self.updateColumn(column)
+            self.cardListViewModel.updateCardList(column?.cards)
+        })
+        cardListViewModel.updateNotify { (cardList) in
+            self.cardListDataSource.updateCardList(cardList)
+        }
+    }
+    
+    private func configureTableView() {
+        tableView.dataSource = cardListDataSource
+        tableView.delegate = cardListDelegate
+    }
+    
+    private func configureColumnView() {
+        columnView.badgeView = badgeView
+        columnView.badgeLabel = badgeLabel
+        columnView.nameLabel = columnNameLabel
+        columnView.addCardButton = addCardButton
     }
 }

--- a/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
@@ -56,6 +56,13 @@ class ColumnViewController: UIViewController, NewCardDelegation {
         tableView.insertRows(at: [IndexPath(row: 0, section: 0)], with: .top)
         tableView.endUpdates()
     }
+    
+    func removeCard(at index: Int) {
+        tableView.beginUpdates()
+        cardListViewModel.removeCard(at: index)
+        tableView.deleteRows(at: [IndexPath(row: index, section: 0)], with: .left)
+        tableView.endUpdates()
+    }
 }
 
 extension ColumnViewController {

--- a/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
@@ -74,7 +74,7 @@ class ColumnViewController: UIViewController, NewCardDelegation {
     
     func addNewCard(_ card: Card) {
         tableView.beginUpdates()
-        columnViewModel?.insertCard(card, at: 0)
+        cardListViewModel.insertCard(card, at: 0)
         tableView.insertRows(at: [IndexPath(row: 0, section: 0)], with: .top)
         tableView.endUpdates()
     }

--- a/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
@@ -24,6 +24,7 @@ class ColumnViewController: UIViewController, NewCardDelegation {
     let delegate = CardListDelegate()
     
     var columnViewModel: ColumnViewModel? { didSet { configureViewModelHandler() } }
+    private var cardListViewModel = CardListViewModel()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -38,7 +39,11 @@ class ColumnViewController: UIViewController, NewCardDelegation {
     private func configureViewModelHandler() {
         columnViewModel?.updateNotify(changed: { (column) in
             self.updateColumn(column)
+            self.cardListViewModel.updateCardList(column?.cards)
         })
+        cardListViewModel.updateNotify { (cardList) in
+            self.dataSource.updateCardList(cardList)
+        }
     }
     
     private func configureTableView() {
@@ -57,7 +62,7 @@ class ColumnViewController: UIViewController, NewCardDelegation {
         guard let column = column else { return }
         columnView.updateName(column.name)
         columnView.updateBadge(column.cards)
-        dataSource.cards = column.cards
+        dataSource.updateCardList(column.cards)
         tableView.reloadData()
     }
     

--- a/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
@@ -43,7 +43,7 @@ class ColumnViewController: UIViewController, NewCardDelegation {
         tableView.reloadData()
     }
     
-    @IBAction func addNewCardButtonTapped(_ sender: Any) {
+    @IBAction func toAddNewCardButtonTapped(_ sender: Any) {
         guard let newCardViewController = storyboard?.instantiateViewController(withIdentifier: "newCard") as? NewCardViewController else { return }
         present(newCardViewController, animated: true, completion: {
             newCardViewController.newCardDelegate = self

--- a/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
@@ -19,8 +19,8 @@ class ColumnViewController: UIViewController, NewCardDelegation {
     @IBOutlet weak var addCardButton: UIButton!
     @IBOutlet weak var tableView: UITableView!
     
-    let dataSource = CardListDataSource()
-    let delegate = CardListDelegate()
+    let cardListDataSource = CardListDataSource()
+    let cardListDelegate = CardListDelegate()
     
     var columnViewModel: ColumnViewModel? { didSet { configureViewModelHandler() } }
     private var cardListViewModel = CardListViewModel()
@@ -41,13 +41,13 @@ class ColumnViewController: UIViewController, NewCardDelegation {
             self.cardListViewModel.updateCardList(column?.cards)
         })
         cardListViewModel.updateNotify { (cardList) in
-            self.dataSource.updateCardList(cardList)
+            self.cardListDataSource.updateCardList(cardList)
         }
     }
     
     private func configureTableView() {
-        tableView.dataSource = dataSource
-        tableView.delegate = delegate
+        tableView.dataSource = cardListDataSource
+        tableView.delegate = cardListDelegate
     }
     
     private func configureColumnView() {
@@ -61,7 +61,7 @@ class ColumnViewController: UIViewController, NewCardDelegation {
         guard let column = column else { return }
         columnView.updateName(column.name)
         columnView.updateBadge(column.cards)
-        dataSource.updateCardList(column.cards)
+        cardListDataSource.updateCardList(column.cards)
         tableView.reloadData()
     }
     

--- a/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/ViewControllers/ColumnViewController.swift
@@ -17,7 +17,6 @@ class ColumnViewController: UIViewController, NewCardDelegation {
     @IBOutlet weak var badgeLabel: UILabel!
     @IBOutlet weak var columnNameLabel: UILabel!
     @IBOutlet weak var addCardButton: UIButton!
-    
     @IBOutlet weak var tableView: UITableView!
     
     let dataSource = CardListDataSource()

--- a/client-mobile/ToDoListApp/ToDoListApp/ViewModels/CardListViewModel.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/ViewModels/CardListViewModel.swift
@@ -19,8 +19,8 @@ class CardListViewModel: ViewModelBinding {
         changeHandler(cardList)
     }
     
-    func updateCardList(_ cardList: [Card]) {
-        self.cardList = cardList
+    func updateCardList(_ cardList: [Card]?) {
+        self.cardList = cardList ?? []
     }
     
     func updateNotify(changed: @escaping ([Card]) -> Void) {

--- a/client-mobile/ToDoListApp/ToDoListApp/ViewModels/CardListViewModel.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/ViewModels/CardListViewModel.swift
@@ -1,0 +1,37 @@
+//
+//  CardListViewModel.swift
+//  ToDoListApp
+//
+//  Created by Cory Kim on 2020/04/13.
+//  Copyright © 2020 corykim0829. All rights reserved.
+//
+
+import Foundation
+
+class CardListViewModel: ViewModelBinding {
+    typealias Key = [Card]
+    private var cardList: Key = [] { didSet { changeHandler(cardList) } }
+    private var changeHandler: (Key) -> Void
+    
+    init(with cardList: [Card] = [], changed handler: @escaping (Key) -> Void = { _ in } ) {
+        self.changeHandler = handler
+        self.cardList = cardList
+        changeHandler(cardList)
+    }
+    
+    func updateCardList(_ cardList: [Card]) {
+        self.cardList = cardList
+    }
+    
+    func updateNotify(changed: @escaping ([Card]) -> Void) {
+        self.changeHandler = changed
+    }
+    
+    func insertCard(_ card: Card, at index: Int) {
+        cardList.insert(card, at: index)
+    }
+    
+    func removeCard(at index: Int) {
+        cardList.remove(at: index)
+    }
+}

--- a/client-mobile/ToDoListApp/ToDoListApp/ViewModels/ColumnViewModel.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/ViewModels/ColumnViewModel.swift
@@ -32,8 +32,4 @@ class ColumnViewModel: ViewModelBinding {
     func updateNotify(changed: @escaping (Column?) -> Void) {
         self.changeHandler = changed
     }
-    
-    func insertCard(_ card: Card, at index: Int) {
-        column?.insertCard(card, at: index)
-    }
 }

--- a/client-mobile/ToDoListApp/ToDoListApp/Views/CardList/BadgeView.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/Views/CardList/BadgeView.swift
@@ -8,10 +8,10 @@
 
 import UIKit
 
-class BedgeView: UIView {
+class BadgeView: UIView {
     
     fileprivate let height: CGFloat = 26
-    var bedgeLabel: UILabel!
+    var badgeLabel: UILabel!
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -27,7 +27,7 @@ class BedgeView: UIView {
         layer.cornerRadius = height / 2
     }
     
-    func updateBedge(bedgeCount count: Int) {
-        bedgeLabel.text = String(count)
+    func updateBadge(badgeCount count: Int) {
+        badgeLabel.text = String(count)
     }
 }

--- a/client-mobile/ToDoListApp/ToDoListApp/Views/CardList/CardListDataSource.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/Views/CardList/CardListDataSource.swift
@@ -10,19 +10,19 @@ import UIKit
 
 class CardListDataSource: NSObject, UITableViewDataSource {
     
-    private var cards: [Card] = []
+    private var cardList: [Card] = []
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return cards.count
+        return cardList.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: CardCell.identifier, for: indexPath) as! CardCell
-        cell.card = cards[indexPath.item]
+        cell.card = cardList[indexPath.item]
         return cell
     }
     
     func updateCardList(_ cardList: [Card]) {
-        self.cards = cardList
+        self.cardList = cardList
     }
 }

--- a/client-mobile/ToDoListApp/ToDoListApp/Views/CardList/CardListDataSource.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/Views/CardList/CardListDataSource.swift
@@ -21,4 +21,8 @@ class CardListDataSource: NSObject, UITableViewDataSource {
         cell.card = cards[indexPath.item]
         return cell
     }
+    
+    func updateCardList(_ cardList: [Card]) {
+        self.cards = cardList
+    }
 }

--- a/client-mobile/ToDoListApp/ToDoListApp/Views/CardList/CardListDataSource.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/Views/CardList/CardListDataSource.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class CardListDataSource: NSObject, UITableViewDataSource {
     
-    var cards: [Card] = []
+    private var cards: [Card] = []
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return cards.count

--- a/client-mobile/ToDoListApp/ToDoListApp/Views/CardList/ColumnView.swift
+++ b/client-mobile/ToDoListApp/ToDoListApp/Views/CardList/ColumnView.swift
@@ -10,8 +10,8 @@ import UIKit
 
 class ColumnView: UIView {
 
-    var bedgeView: BedgeView!
-    var bedgeLabel: UILabel! { didSet { bedgeView.bedgeLabel = bedgeLabel } }
+    var badgeView: BadgeView!
+    var badgeLabel: UILabel! { didSet { badgeView.badgeLabel = badgeLabel } }
     var nameLabel: UILabel!
     var addCardButton: UIButton!
     
@@ -19,7 +19,7 @@ class ColumnView: UIView {
         nameLabel.text = name
     }
     
-    func updateBedge(_ cards: [Card]) {
-        bedgeView.updateBedge(bedgeCount: cards.count)
+    func updateBadge(_ cards: [Card]) {
+        badgeView.updateBadge(badgeCount: cards.count)
     }
 }


### PR DESCRIPTION
CardLIstViewModel을 만들어서 하나의 '칼럼'마다 소유하게 해 카드들을 관리하게 하였습니다. 
ColumnViewModel을 통해 받아온 cardList를 CardListViewModel에 넣어주었습니다.
CardLIstViewModel가 가지고 있는 CardList가 변경사항이 있을 때마다 dataSource를 업데이트 해주었고 reloadData를 사용하지 않고, tableView 메소드를 사용하여 하나의 카드에 대한 업데이트를 반영하게 하였습니다.
